### PR TITLE
Fix deep equal cyclical

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "deep-equal": "^1.0.1",
     "es6-error": "^2.1.0",
     "hoist-non-react-statics": "^1.0.5",
-    "is-promise": "^2.1.0"
+    "is-promise": "^2.1.0",
+    "lodash.isequalwith": "^4.1.4"
   },
   "devDependencies": {
     "babel-cli": "^6.3.17",

--- a/src/structure/immutable/__tests__/deepEqual.spec.js
+++ b/src/structure/immutable/__tests__/deepEqual.spec.js
@@ -1,5 +1,5 @@
 import deepEqual from '../deepEqual'
-import { fromJS } from 'immutable'
+import { fromJS, List } from 'immutable'
 import expectations from '../expectations'
 import addExpectations from '../../../__tests__/addExpectations'
 
@@ -189,6 +189,33 @@ describe('structure.immutable.deepEqual', () => {
       },
       f: 4
     }, false)
+  })
+
+  it('should work with Immutable.Lists', () => {
+    let firstObj = { a: 1 }
+    let secondObj = { a: 1 }
+    let thirdObj = { c: 1 }
+
+    testBothWays(
+      List([ 'a', 'b' ]),
+      List([ 'a', 'b', 'c' ]),
+      false
+    )
+    testBothWays(
+      List([ 'a', 'b', 'c' ]),
+      List([ 'a', 'b', 'c' ]),
+      true
+    )
+    testBothWays(
+      List([ 'a', 'b', firstObj ]),
+      List([ 'a', 'b', secondObj ]),
+      true
+    )
+    testBothWays(
+      List([ 'a', 'b', firstObj ]),
+      List([ 'a', 'b', thirdObj ]),
+      false
+    )
   })
 
   it('should work with plain objects with cycles', () => {

--- a/src/structure/immutable/__tests__/deepEqual.spec.js
+++ b/src/structure/immutable/__tests__/deepEqual.spec.js
@@ -52,7 +52,7 @@ describe('structure.immutable.deepEqual', () => {
     }), false)
   })
 
-  it('work with plain objects', () => {
+  it('should work with plain objects', () => {
     testBothWays({
       a: {
         b: {
@@ -189,6 +189,31 @@ describe('structure.immutable.deepEqual', () => {
       },
       f: 4
     }, false)
+  })
+
+  it('should work with plain objects with cycles', () => {
+    // Set up cyclical structures:
+    //
+    // base1, base2 {
+    //   a: 1,
+    //   deep: {
+    //     b: 2,
+    //     base: {
+    //       a: 1,
+    //       deep: { ... }
+    //     }
+    //   }
+    // }
+
+    let base1 = { a: 1 }
+    let deep1 = { b: 2, base: base1 }
+    base1.deep = deep1
+
+    let base2 = { a: 1 }
+    let deep2 = { b : 2, base: base2 }
+    base2.deep = deep2
+
+    testBothWays(base1, base2, true)
   })
 
   it('should treat undefined and \'\' as equal', () => {

--- a/src/structure/immutable/deepEqual.js
+++ b/src/structure/immutable/deepEqual.js
@@ -1,20 +1,22 @@
 import { Iterable } from 'immutable'
-import every from '../../util/every'
+
+import isEqualWith from 'lodash.isEqualWith'
+
+const customizer = (obj, other) => {
+  if (obj === undefined && other === '') return true
+  if (obj === '' && other === undefined) return true
+
+  if (Iterable.isIterable(obj) && Iterable.isIterable(other)) {
+    return obj.count() === other.count() && obj.every((value, key) => {
+      return isEqualWith(value, other.get(key), customizer)
+    })
+  }
+
+  return void 0
+}
 
 const deepEqualValues = (a, b) => {
-  if (a === undefined && b === '') return true
-  if (a === '' && b === undefined) return true
-  if (Iterable.isIterable(a)) {
-    if (Iterable.isIterable(b)) {
-      return a.count() === b.count() &&
-        a.every((value, key) => deepEqualValues(value, b.get(key)))
-    }
-    return false
-  }
-  if (!a || !b || typeof a != 'object' && typeof b != 'object') {
-    return a === b
-  }
-  return every(a, (value, key) => deepEqualValues(value, b[key]))
+  return isEqualWith(a, b, customizer)
 }
 
 export default deepEqualValues


### PR DESCRIPTION
Fixes #919 by outsourcing some deep equal logic to `lodash.isEqualWith`.